### PR TITLE
Allow identity transitions

### DIFF
--- a/decision-log/2023-01-13-always-allow-identity-transitions.yaml
+++ b/decision-log/2023-01-13-always-allow-identity-transitions.yaml
@@ -16,3 +16,6 @@ consequences: >
 
   This implies that it is not necessary to specify in a topology that every
   trivial transition is allowed.
+  
+  Moreover this implies that with library we will not be able to model machines
+  that do not allow any trivial transition.

--- a/decision-log/2023-01-13-always-allow-identity-transitions.yaml
+++ b/decision-log/2023-01-13-always-allow-identity-transitions.yaml
@@ -1,0 +1,18 @@
+name: Always allow identity transitions
+date: 2023-01-13
+context: >
+  The topology of a state machine describes which are the allowed transitions.
+
+  Sometimes (like in the implementation of the `Choice` typeclass) we would
+  simply like to say that we are not changing state. This is still seen as a
+  transition by our current implementation.
+decision: >
+  We decide to consider everytime not changing state as a valid transition.
+consequences: >
+  We create a new instance of our `AllowedTransition` typeclass which searches
+  for a proof term indicating that a transition is allowed. Such an instance
+  says that going from a vertex to itself in the space of the states of the
+  machine is always allowed.
+
+  This implies that it is not necessary to specify in a topology that every
+  trivial transition is allowed.

--- a/decision-log/2023-01-13-always-allow-identity-transitions.yaml
+++ b/decision-log/2023-01-13-always-allow-identity-transitions.yaml
@@ -1,13 +1,13 @@
 name: Always allow identity transitions
 date: 2023-01-13
 context: >
-  The topology of a state machine describes which are the allowed transitions.
+  The topology of a state machine lists its allowed transitions.
 
   Sometimes (like in the implementation of the `Choice` typeclass) we would
   simply like to say that we are not changing state. This is still seen as a
   transition by our current implementation.
 decision: >
-  We decide to consider everytime not changing state as a valid transition.
+  We will always consider not changing state as a valid transition.
 consequences: >
   We create a new instance of our `AllowedTransition` typeclass which searches
   for a proof term indicating that a transition is allowed. Such an instance

--- a/spec/CRM/Example/LockDoor.hs
+++ b/spec/CRM/Example/LockDoor.hs
@@ -24,9 +24,9 @@ $( singletons
       lockDoorTopology :: Topology LockDoorVertex
       lockDoorTopology =
         Topology
-          [ (IsLockOpen, [IsLockOpen, IsLockClosed])
-          , (IsLockClosed, [IsLockClosed, IsLockOpen, IsLockLocked])
-          , (IsLockLocked, [IsLockLocked, IsLockClosed])
+          [ (IsLockOpen, [IsLockClosed])
+          , (IsLockClosed, [IsLockOpen, IsLockLocked])
+          , (IsLockLocked, [IsLockClosed])
           ]
       |]
  )

--- a/spec/CRM/Example/OneState.hs
+++ b/spec/CRM/Example/OneState.hs
@@ -13,7 +13,7 @@ $( singletons
     [d|
       -- topology with a single vertex and one edge from the vertex to itself
       singleVertexTopology :: Topology ()
-      singleVertexTopology = Topology [((), [()])]
+      singleVertexTopology = Topology []
       |]
  )
 

--- a/spec/CRM/RenderSpec.hs
+++ b/spec/CRM/RenderSpec.hs
@@ -84,23 +84,23 @@ spec =
             , "() --> ()"
             ]
 
-      it "should render the basic switch machine" $ do
-        renderUntypedMermaid (machineAsGraph (Basic switchMachine))
-          `shouldBe` Text.unlines
-            [ "stateDiagram-v2"
-            , "True --> False"
-            , "False --> True"
-            ]
+-- it "should render the basic switch machine" $ do
+--   renderUntypedMermaid (machineAsGraph (Basic switchMachine))
+--     `shouldBe` Text.unlines
+--       [ "stateDiagram-v2"
+--       , "True --> False"
+--       , "False --> True"
+--       ]
 
-      it "should render the basic lockDoor machine" $ do
-        renderUntypedMermaid (machineAsGraph (Basic lockDoorMachine))
-          `shouldBe` Text.unlines
-            [ "stateDiagram-v2"
-            , "IsLockOpen --> IsLockOpen"
-            , "IsLockOpen --> IsLockClosed"
-            , "IsLockClosed --> IsLockClosed"
-            , "IsLockClosed --> IsLockOpen"
-            , "IsLockClosed --> IsLockLocked"
-            , "IsLockLocked --> IsLockLocked"
-            , "IsLockLocked --> IsLockClosed"
-            ]
+-- it "should render the basic lockDoor machine" $ do
+--   renderUntypedMermaid (machineAsGraph (Basic lockDoorMachine))
+--     `shouldBe` Text.unlines
+--       [ "stateDiagram-v2"
+--       , "IsLockOpen --> IsLockOpen"
+--       , "IsLockOpen --> IsLockClosed"
+--       , "IsLockClosed --> IsLockClosed"
+--       , "IsLockClosed --> IsLockOpen"
+--       , "IsLockClosed --> IsLockLocked"
+--       , "IsLockLocked --> IsLockLocked"
+--       , "IsLockLocked --> IsLockClosed"
+--       ]

--- a/spec/CRM/RenderSpec.hs
+++ b/spec/CRM/RenderSpec.hs
@@ -27,9 +27,7 @@ spec =
     describe "topologyAsGraph" $ do
       it "should render the topology with a single vertex" $ do
         topologyAsGraph singleVertexTopology
-          `shouldBe` Graph
-            [ ((), ())
-            ]
+          `shouldBe` Graph []
 
       it "should render the switch topology" $ do
         topologyAsGraph switchTopology
@@ -41,21 +39,16 @@ spec =
       it "should render the lockDoor topology" $ do
         topologyAsGraph lockDoorTopology
           `shouldBe` Graph
-            [ (IsLockOpen, IsLockOpen)
-            , (IsLockOpen, IsLockClosed)
-            , (IsLockClosed, IsLockClosed)
+            [ (IsLockOpen, IsLockClosed)
             , (IsLockClosed, IsLockOpen)
             , (IsLockClosed, IsLockLocked)
-            , (IsLockLocked, IsLockLocked)
             , (IsLockLocked, IsLockClosed)
             ]
 
     describe "baseMachineAsGraph" $ do
       it "should render the machine with a single vertex" $ do
         baseMachineAsGraph oneVertexMachine
-          `shouldBe` Graph
-            [ ((), ())
-            ]
+          `shouldBe` Graph []
 
       it "should render the switch machine" $ do
         baseMachineAsGraph switchMachine
@@ -67,12 +60,9 @@ spec =
       it "should render the lockDoor machine" $ do
         baseMachineAsGraph lockDoorMachine
           `shouldBe` Graph
-            [ (IsLockOpen, IsLockOpen)
-            , (IsLockOpen, IsLockClosed)
-            , (IsLockClosed, IsLockClosed)
+            [ (IsLockOpen, IsLockClosed)
             , (IsLockClosed, IsLockOpen)
             , (IsLockClosed, IsLockLocked)
-            , (IsLockLocked, IsLockLocked)
             , (IsLockLocked, IsLockClosed)
             ]
 
@@ -81,26 +71,22 @@ spec =
         renderUntypedMermaid (machineAsGraph (Basic oneVertexMachine))
           `shouldBe` Text.unlines
             [ "stateDiagram-v2"
-            , "() --> ()"
             ]
 
--- it "should render the basic switch machine" $ do
---   renderUntypedMermaid (machineAsGraph (Basic switchMachine))
---     `shouldBe` Text.unlines
---       [ "stateDiagram-v2"
---       , "True --> False"
---       , "False --> True"
---       ]
+      it "should render the basic switch machine" $ do
+        renderUntypedMermaid (machineAsGraph (Basic switchMachine))
+          `shouldBe` Text.unlines
+            [ "stateDiagram-v2"
+            , "True --> False"
+            , "False --> True"
+            ]
 
--- it "should render the basic lockDoor machine" $ do
---   renderUntypedMermaid (machineAsGraph (Basic lockDoorMachine))
---     `shouldBe` Text.unlines
---       [ "stateDiagram-v2"
---       , "IsLockOpen --> IsLockOpen"
---       , "IsLockOpen --> IsLockClosed"
---       , "IsLockClosed --> IsLockClosed"
---       , "IsLockClosed --> IsLockOpen"
---       , "IsLockClosed --> IsLockLocked"
---       , "IsLockLocked --> IsLockLocked"
---       , "IsLockLocked --> IsLockClosed"
---       ]
+      it "should render the basic lockDoor machine" $ do
+        renderUntypedMermaid (machineAsGraph (Basic lockDoorMachine))
+          `shouldBe` Text.unlines
+            [ "stateDiagram-v2"
+            , "IsLockOpen --> IsLockClosed"
+            , "IsLockClosed --> IsLockOpen"
+            , "IsLockClosed --> IsLockLocked"
+            , "IsLockLocked --> IsLockClosed"
+            ]

--- a/src/CRM/StateMachine.hs
+++ b/src/CRM/StateMachine.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE QuantifiedConstraints #-}
 
 module CRM.StateMachine where
 
@@ -18,7 +17,6 @@ data StateMachine input output where
        , SingKind vertex
        , SingI topology
        , Show vertex
-       , forall (vertex' :: vertex). AllowedTransition topology vertex' vertex'
        )
     => BaseMachine topology input output
     -> StateMachine input output

--- a/src/CRM/StateMachine.hs
+++ b/src/CRM/StateMachine.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE QuantifiedConstraints #-}
 
 module CRM.StateMachine where
 
@@ -13,7 +14,12 @@ import "singletons-base" Data.Singletons (Demote, SingI, SingKind)
 data StateMachine input output where
   Basic
     :: forall vertex (topology :: Topology vertex) input output
-     . (Demote (Topology vertex) ~ Topology vertex, SingKind vertex, SingI topology, Show vertex)
+     . ( Demote (Topology vertex) ~ Topology vertex
+       , SingKind vertex
+       , SingI topology
+       , Show vertex
+       , forall (vertex' :: vertex). AllowedTransition topology vertex' vertex'
+       )
     => BaseMachine topology input output
     -> StateMachine input output
   Compose

--- a/src/CRM/Topology.hs
+++ b/src/CRM/Topology.hs
@@ -27,6 +27,8 @@ $( singletons
 -- that the `topology` allows transitions from the`initial` to the `final`
 -- state
 data AllowTransition (topology :: Topology vertex) (initial :: vertex) (final :: vertex) where
+  -- | We always allow an edge from a vertex to itself
+  AllowIdentityEdge :: AllowTransition topology a a
   -- | If `a` is the start and `b` is the end of the first edge,
   -- then `map` contains an edge from `a` to `b`
   AllowFirstEdge :: AllowTransition ('Topology ('(a, b : l1) : l2)) a b
@@ -44,13 +46,16 @@ data AllowTransition (topology :: Topology vertex) (initial :: vertex) (final ::
 class AllowedTransition (topology :: Topology vertex) (initial :: vertex) (final :: vertex) where
   allowsTransition :: AllowTransition topology initial final
 
-instance {-# OVERLAPPING #-} AllowedTransition ('Topology ('(a, b : l1) : l2)) a b where
+instance {-# INCOHERENT #-} AllowedTransition ('Topology ('(a, b : l1) : l2)) a b where
   allowsTransition = AllowFirstEdge
 
-instance {-# OVERLAPPING #-} AllowedTransition ('Topology ('(a, l1) : l2)) a b => AllowedTransition ('Topology ('(a, x : l1) : l2)) a b where
+instance {-# INCOHERENT #-} AllowedTransition ('Topology ('(a, l1) : l2)) a b => AllowedTransition ('Topology ('(a, x : l1) : l2)) a b where
   allowsTransition =
     AllowAddingEdge (allowsTransition :: AllowTransition ('Topology ('(a, l1) : l2)) a b)
 
-instance AllowedTransition ('Topology map) a b => AllowedTransition ('Topology (x : map)) a b where
+instance {-# INCOHERENT #-} AllowedTransition ('Topology map) a b => AllowedTransition ('Topology (x : map)) a b where
   allowsTransition =
     AllowAddingVertex (allowsTransition :: AllowTransition ('Topology map) a b)
+
+instance {-# INCOHERENT #-} AllowedTransition topology a a where
+  allowsTransition = AllowIdentityEdge


### PR DESCRIPTION
Practically, this is needed to implement the `Choice` typeclass for a state machine.

Since in choice the state machine evolves depending on the input, it could happen that it stays where it is. Therefore we always allow the identity transition, so that such case is always allowed