### PR TITLE
add utility to open haddock docs in the browser

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -93,6 +93,28 @@
         cabal build --write-ghc-environment-files=always
         cabal test --test-show-details=streaming
       '';
+
+      open-haddock =
+        let
+          defaultPackage = ".#packages.${system}.default";
+        in
+        pkgs.writeScriptBin "open-haddock" ''
+          pkgName=$(nix eval --raw ${defaultPackage}.name)
+
+          echo Building Haddock documentation for $pkgName
+          docPath=$(nix build --no-link --print-out-paths ${defaultPackage}.doc)
+
+          index="file://$docPath/share/doc/$pkgName/html/index.html"
+          echo "Haddock documentation is available at: $index"
+
+          ${
+            if pkgs.stdenv.isLinux
+            then "xdg-open $index"
+            else if pkgs.stdenv.isDarwin
+            then "open $index"
+            else ""
+          }
+        '';
     in
     rec {
       packages = {
@@ -120,6 +142,7 @@
               haskell-language-server
               build-watch
               test-watch
+              open-haddock
               pkgs.hpack
             ];
             shellHook = ''


### PR DESCRIPTION
This PR adds the poorly-named `open-haddock` command, which builds the Haddock documentation and opens it in the browser.

Closes #3