### PR TITLE
Costrong machines

### DIFF
--- a/decision-log/2023-01-25-loop-constructor.yaml
+++ b/decision-log/2023-01-25-loop-constructor.yaml
@@ -1,0 +1,41 @@
+name: Add Loop constructor
+date: 2023-01-25
+context: >
+  We would like to have machines which are able to feed back their output as
+  input to themselves, if types align correctly.
+
+  One option to do this is to use the `Costrong` instance for machines, or
+  similarly an `ArrowLoop` instance. This would require the use of a `fix`
+  style using `unfirst` or `loop`.
+
+  The other option is adding a new constructor `Loop` to `StateMachine` and use
+  that to loop over the provided machine when the machine is run.
+  In general it does not make much sense to loopa machine of type
+  `StateMachine a a`, since that would mean never stopping.
+  One option to signal the stopping would be to restrict `Loop` only to
+  machines with an output of type `m b`, where `m` admits and instance of
+  `MonadError e m`. This does not work as good as we would like, since we are
+  very much interested in using `m = []` and currently there is no `MonadError`
+  instance for lists.
+  The other option is using directly `Loop` only on machines of type
+  `StateMachine a [a]`. This also makes sense since `StateMachine a b` is
+  isomorphic to `(NonEmpty a) -> b` and then `[a]` could be seen as the sum of
+  the stop case (`[]`) and the continuation case `NonEmpty a`.
+
+  Moreover, adding a new constructor, we could use that information when we
+  need to represent graphically our machines.
+decision: >
+  For the moment, until we understand more about the categorical setting which
+  underlies the issue, we are going to use
+
+  ```
+  Loop :: StateMachine a [a] -> StateMachine a [a]
+  ```
+consequences: >
+  A new `Loop` constructor is added to the `StateMachine` data type.
+
+  For the moment we can compute the topology of a looping machine as transitive
+  closure of the original topology.
+
+  It could be possible in the future to use that information in representing
+  correctly the flow on the machine.

--- a/package.yaml
+++ b/package.yaml
@@ -112,8 +112,10 @@ tests:
     dependencies:
       - crm
       - hspec
+      - profunctors
       - singletons-base
       - text
+      - QuickCheck
     when:
     - condition: false
       other-modules: Paths_crm

--- a/spec/CRM/Example/OneState.hs
+++ b/spec/CRM/Example/OneState.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE GADTs #-}
 
 module CRM.Example.OneState where
 
@@ -9,15 +7,7 @@ import "crm" CRM.BaseMachine
 import "crm" CRM.Topology
 import "singletons-base" Data.Singletons.Base.TH
 
-$( singletons
-    [d|
-      -- topology with a single vertex and one edge from the vertex to itself
-      singleVertexTopology :: Topology ()
-      singleVertexTopology = Topology []
-      |]
- )
-
-oneVertexMachine :: BaseMachine SingleVertexTopology () ()
+oneVertexMachine :: BaseMachine (TrivialTopology @()) () ()
 oneVertexMachine =
   BaseMachine
     { initialState = InitialState STuple0

--- a/spec/CRM/Example/PlusOneUpToFour.hs
+++ b/spec/CRM/Example/PlusOneUpToFour.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE GADTs #-}
+
+module CRM.Example.PlusOneUpToFour where
+
+import "crm" CRM.StateMachine (StateMachine, stateless)
+
+plus1UpTo4 :: StateMachine Int [Int]
+plus1UpTo4 =
+  stateless (\i -> [i + 1 | i < 5])

--- a/spec/CRM/Example/TriangularMachine.hs
+++ b/spec/CRM/Example/TriangularMachine.hs
@@ -1,0 +1,22 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+
+module CRM.Example.TriangularMachine where
+
+import CRM.BaseMachine (ActionResult (..), InitialState (..))
+import CRM.StateMachine (StateMachine, unrestrictedMachine)
+
+data TriangularState (a :: ()) where
+  OnlyState :: Int -> TriangularState '()
+
+triangular :: StateMachine Int Int
+triangular =
+  unrestrictedMachine
+    ( \case
+        OnlyState state ->
+          \input ->
+            ActionResult
+              (OnlyState $ state + 1)
+              (state + input)
+    )
+    (InitialState (OnlyState 0))

--- a/spec/CRM/GraphSpec.hs
+++ b/spec/CRM/GraphSpec.hs
@@ -18,3 +18,10 @@ spec =
             , ((1, 'a'), (2, 'b'))
             , ((1, 'c'), (2, 'd'))
             ]
+
+    describe "transitiveClosureGraph" $ do
+      it "computes correctly the transitive closure of a graph" $
+        do
+          transitiveClosureGraph
+            (Graph [(1 :: Int, 2), (2, 3), (1, 4)])
+          `shouldBe` Graph [(2, 3), (1, 2), (1, 4), (1, 3)]

--- a/spec/CRM/RenderSpec.hs
+++ b/spec/CRM/RenderSpec.hs
@@ -6,6 +6,7 @@ import CRM.Example.Switch
 import "crm" CRM.Graph
 import "crm" CRM.Render
 import "crm" CRM.StateMachine
+import CRM.Topology (trivialTopology)
 import Data.Singletons.Base.TH
 import "text" Data.Text as Text (unlines)
 import "hspec" Test.Hspec (Spec, describe, it, shouldBe)
@@ -27,7 +28,7 @@ spec =
 
     describe "topologyAsGraph" $ do
       it "should render the topology with a single vertex" $ do
-        topologyAsGraph singleVertexTopology
+        topologyAsGraph (trivialTopology @())
           `shouldBe` Graph []
 
       it "should render the switch topology" $ do

--- a/spec/CRM/StateMachineSpec.hs
+++ b/spec/CRM/StateMachineSpec.hs
@@ -2,6 +2,7 @@ module CRM.StateMachineSpec where
 
 import CRM.Example.BooleanStateMachine (booleanStateMachine)
 import CRM.Example.LockDoor
+import CRM.Example.PlusOneUpToFour (plus1UpTo4)
 import CRM.Example.Switch (switchMachine)
 import "crm" CRM.StateMachine
 import "base" Data.List.NonEmpty (NonEmpty, fromList)
@@ -108,3 +109,12 @@ spec =
           \input ->
             nonEmptyFunction input
               `shouldBe` (cosieve . cotabulate @StateMachine $ nonEmptyFunction) input
+
+    describe "Loop constructor runs correctly" $ do
+      describe "with the plus1UpTo4 machine" $ do
+        it "runs correctly on a single input" $ do
+          run (Loop plus1UpTo4) 1 `shouldOutput` [2, 3, 4, 5]
+          run (Loop plus1UpTo4) 5 `shouldOutput` []
+
+        it "processes correctly multiple inputs" $ do
+          runMultiple (Loop plus1UpTo4) [1, 1] `shouldOutput` [2, 3, 4, 5, 2, 3, 4, 5]

--- a/src/CRM/Render.hs
+++ b/src/CRM/Render.hs
@@ -54,3 +54,5 @@ machineAsGraph (Alternative machine1 machine2) =
   untypedProductGraph
     (machineAsGraph machine1)
     (machineAsGraph machine2)
+machineAsGraph (Loop machine) =
+  untypedTransitiveClosureGraph (machineAsGraph machine)

--- a/src/CRM/Topology.hs
+++ b/src/CRM/Topology.hs
@@ -18,7 +18,8 @@ import "singletons-base" Prelude.Singletons
 -- It contains the collection of allowed transitions
 $( singletons
     [d|
-      newtype Topology vertex = Topology {edges :: [(vertex, [vertex])]}
+      newtype Topology vertex = Topology
+        {edges :: [(vertex, [vertex])]}
       |]
  )
 
@@ -66,7 +67,9 @@ instance {-# INCOHERENT #-} AllowedTransition topology a a where
 -- | The trivial topology only allows identity transitions.
 $( singletons
     [d|
-      trivialTopology :: Topology ()
+      -- Given a type `a` for vertices, only trivial transitions, i.e. staying
+      -- at the same vertex, are allowed
+      trivialTopology :: Topology a
       trivialTopology = Topology []
       |]
  )
@@ -75,6 +78,8 @@ $( singletons
 
 $( singletons
     [d|
+      -- Given a type `a` for vertices, every transition from one vertex to
+      -- any other is allowed
       allowAllTopology :: (Bounded a, Enum a) => Topology a
       allowAllTopology = Topology [(a, [minBound .. maxBound]) | a <- [minBound .. maxBound]]
       |]


### PR DESCRIPTION
Adds the ability to construct looping machines which feed their outputs directly to themselves as input.

This could be achieved in two ways, actually:
- using the `Costrong` instance, using a `fix`-like style
- using the new `Loop` constructor, which preserves more information for static analysis