### PR TITLE
add cabal version constraints

### DIFF
--- a/crem.cabal
+++ b/crem.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.35.1.
+-- This file has been generated from package.yaml by hpack version 0.35.2.
 --
 -- see: https://github.com/sol/hpack
 
@@ -32,10 +32,10 @@ library
       PackageImports
   ghc-options: -Weverything -Werror -Wno-safe -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-implicit-prelude -Wno-missing-export-lists -Wno-missing-home-modules -Wno-missing-import-lists -Wno-all-missed-specialisations
   build-depends:
-      base
-    , profunctors
-    , singletons-base
-    , text
+      base >=4.15 && <4.19
+    , profunctors >=3.2 && <5.7
+    , singletons-base >=3.0 && <3.2
+    , text >=1.2 && <2.1
   default-language: Haskell2010
   if impl(ghc >= 9.2)
     ghc-options: -Wno-missing-kind-signatures
@@ -112,11 +112,11 @@ library crem-examples
       PackageImports
   ghc-options: -Weverything -Werror -Wno-safe -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-implicit-prelude -Wno-missing-export-lists -Wno-missing-home-modules -Wno-missing-import-lists -Wno-all-missed-specialisations
   build-depends:
-      base
+      base >=4.15 && <4.19
     , crem
-    , profunctors
-    , singletons-base
-    , text
+    , profunctors >=3.2 && <5.7
+    , singletons-base >=3.0 && <3.2
+    , text >=1.2 && <2.1
   default-language: Haskell2010
   if impl(ghc >= 9.2)
     ghc-options: -Wno-missing-kind-signatures
@@ -179,7 +179,7 @@ executable hobbit-game
       PackageImports
   ghc-options: -Weverything -Werror -Wno-safe -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-implicit-prelude -Wno-missing-export-lists -Wno-missing-home-modules -Wno-missing-import-lists -Wno-all-missed-specialisations
   build-depends:
-      base
+      base >=4.15 && <4.19
     , crem
     , crem-examples
   default-language: Haskell2010
@@ -244,10 +244,10 @@ executable hobbit-map
       PackageImports
   ghc-options: -Weverything -Werror -Wno-safe -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-implicit-prelude -Wno-missing-export-lists -Wno-missing-home-modules -Wno-missing-import-lists -Wno-all-missed-specialisations
   build-depends:
-      base
+      base >=4.15 && <4.19
     , crem
     , crem-examples
-    , text
+    , text >=1.2 && <2.1
   default-language: Haskell2010
   if impl(ghc >= 9.2)
     ghc-options: -Wno-missing-kind-signatures
@@ -311,10 +311,10 @@ test-suite crem-doctests
       PackageImports
   ghc-options: -Weverything -Werror -Wno-safe -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-implicit-prelude -Wno-missing-export-lists -Wno-missing-home-modules -Wno-missing-import-lists -Wno-all-missed-specialisations -threaded -Wno-unused-packages
   build-depends:
-      base
+      base >=4.15 && <4.19
     , crem
     , crem-examples
-    , doctest-parallel
+    , doctest-parallel >=0.2.3 && <0.4
   default-language: Haskell2010
   if impl(ghc >= 9.2)
     ghc-options: -Wno-missing-kind-signatures
@@ -387,12 +387,12 @@ test-suite crem-spec
   build-tool-depends:
       hspec-discover:hspec-discover
   build-depends:
-      base
+      base >=4.15 && <4.19
     , crem
     , crem-examples
-    , hspec
-    , profunctors
-    , singletons-base
+    , hspec >=2.7 && <2.11
+    , profunctors >=3.2 && <5.7
+    , singletons-base >=3.0 && <3.2
   default-language: Haskell2010
   if impl(ghc >= 9.2)
     ghc-options: -Wno-missing-kind-signatures

--- a/package.yaml
+++ b/package.yaml
@@ -88,22 +88,17 @@ ghc-options:
   - -Wno-missing-export-lists      # https://downloads.haskell.org/ghc/latest/docs/users_guide/using-warnings.html#ghc-flag--Wmissing-export-lists
   - -Wno-missing-home-modules      # https://downloads.haskell.org/ghc/latest/docs/users_guide/using-warnings.html#ghc-flag--Wmissing-home-modules
   - -Wno-missing-import-lists      # https://downloads.haskell.org/ghc/latest/docs/users_guide/using-warnings.html#ghc-flag--Wmissing-import-lists
-#  - -Wno-unused-type-patterns
   - -Wno-all-missed-specialisations    # https://downloads.haskell.org/ghc/latest/docs/users_guide/using-warnings.html#ghc-flag--Wall-missed-specialisations
-#  - -Wno-orphans
-# TODO: do we still need these?
-# - -fwrite-ide-info
-# - -hiedir=.hie
 
 dependencies:
-  - base
+  - base >= 4.15 && < 4.19
 
 library:
   source-dirs:      src
   dependencies:
-    - profunctors
-    - singletons-base
-    - text
+    - profunctors >= 3.2 && < 5.7
+    - singletons-base >= 3.0 && < 3.2
+    - text >= 1.2 && < 2.1
   # Disable adding Paths_crem to other-modules, because it does not conform to our style guide.
   # https://github.com/sol/hpack#handling-of-paths_-modules
   when:
@@ -115,9 +110,9 @@ internal-libraries:
     source-dirs:      examples
     dependencies:
       - crem
-      - profunctors
-      - singletons-base
-      - text
+      - profunctors >= 3.2 && < 5.7
+      - singletons-base >= 3.0 && < 3.2
+      - text >= 1.2 && < 2.1
     # Disable adding Paths_crem to other-modules, because it does not conform to our style guide.
     # https://github.com/sol/hpack#handling-of-paths_-modules
     when:
@@ -131,9 +126,9 @@ tests:
     dependencies:
       - crem
       - crem-examples
-      - hspec
-      - profunctors
-      - singletons-base
+      - hspec >= 2.7 && < 2.11
+      - profunctors >= 3.2 && < 5.7
+      - singletons-base >= 3.0 && < 3.2
     build-tools: hspec-discover:hspec-discover
     when:
     - condition: false
@@ -148,7 +143,7 @@ tests:
     dependencies:
       - crem
       - crem-examples
-      - doctest-parallel
+      - doctest-parallel >= 0.2.3 && < 0.4
     when:
     - condition: false
       other-modules: Paths_crem
@@ -172,7 +167,7 @@ executables:
     dependencies:
       - crem
       - crem-examples
-      - text
+      - text >= 1.2 && < 2.1
     # Disable adding Paths_crem to other-modules, because it does not conform to our style guide.
     # https://github.com/sol/hpack#handling-of-paths_-modules
     when:


### PR DESCRIPTION
cabal version constraints are useful so that users of `crem` get transitive dependencies which actually make `crem` work correctly