### PR TITLE
Renderable vertices not overlappable

### DIFF
--- a/docs/how-to-create-a-machine.md
+++ b/docs/how-to-create-a-machine.md
@@ -372,7 +372,8 @@ class RenderableVertices a where
 ```
 
 It is used to list all the vertices of type `a` so that they can be rendered.
-It has a default instance for types `a` satisfying `(Enum a, Bounded a)`, but you can overwrite it for more specific types.
+
+For your own types with `Enum` and `Bounded` instances, you can use the `AllVertices` newtype wrapper in conjunction with `deriving via` to derive a `RenderableVertices` instance which returns the list of all the terms of your type.
 
 Be aware that rendering a graph or topology with vertices of type `a` will try to print out every element of that type. It might not be a good idea to try to print out every value of type `Int`, for example...
 

--- a/examples/Crem/Example/LockDoor.hs
+++ b/examples/Crem/Example/LockDoor.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -14,6 +15,7 @@
 module Crem.Example.LockDoor where
 
 import Crem.BaseMachine
+import Crem.Render.RenderableVertices (AllVertices (..), RenderableVertices)
 import Crem.Topology
 import "singletons-base" Data.Singletons.Base.TH
 
@@ -34,6 +36,8 @@ $( singletons
           ]
       |]
  )
+
+deriving via AllVertices LockDoorVertex instance RenderableVertices LockDoorVertex
 
 data LockDoorCommand
   = LockOpen

--- a/examples/Crem/Example/RiskManager/Aggregate.hs
+++ b/examples/Crem/Example/RiskManager/Aggregate.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -13,6 +14,7 @@ module Crem.Example.RiskManager.Aggregate where
 
 import Crem.BaseMachine
 import Crem.Example.RiskManager.Domain
+import Crem.Render.RenderableVertices (AllVertices (..), RenderableVertices)
 import Crem.Topology
 import "singletons-base" Data.Singletons.Base.TH
 
@@ -37,6 +39,8 @@ $( singletons
           ]
       |]
  )
+
+deriving via AllVertices AggregateVertex instance RenderableVertices AggregateVertex
 
 data AggregateState (vertex :: AggregateVertex) where
   NoData :: AggregateState 'NoDataVertex

--- a/examples/Crem/Example/RiskManager/Projection.hs
+++ b/examples/Crem/Example/RiskManager/Projection.hs
@@ -15,6 +15,7 @@ module Crem.Example.RiskManager.Projection where
 
 import Crem.BaseMachine
 import Crem.Example.RiskManager.Domain
+import Crem.Render.RenderableVertices (AllVertices (..), RenderableVertices)
 import Crem.Topology
 import "base" Data.Monoid (Last (..))
 import "base" GHC.Generics (Generic)
@@ -59,6 +60,8 @@ $( singletons
         Topology []
       |]
  )
+
+deriving via AllVertices ProjectionVertex instance RenderableVertices ProjectionVertex
 
 data ProjectionState (vertex :: ProjectionVertex) where
   SingleProjectionState :: ReceivedData -> ProjectionState 'SingleProjectionVertex

--- a/examples/Crem/Example/TheHobbit.hs
+++ b/examples/Crem/Example/TheHobbit.hs
@@ -13,6 +13,7 @@
 module Crem.Example.TheHobbit where
 
 import Crem.BaseMachine
+import Crem.Render.RenderableVertices (AllVertices (..), RenderableVertices)
 import Crem.Topology
 import "base" Data.Semigroup
 import "singletons-base" Data.Singletons.Base.TH
@@ -58,6 +59,8 @@ $( singletons
           ]
       |]
  )
+
+deriving via AllVertices HobbitVertex instance RenderableVertices HobbitVertex
 
 data KeyState
   = NoKey

--- a/examples/Crem/Example/TwoSwitchesGate.lhs
+++ b/examples/Crem/Example/TwoSwitchesGate.lhs
@@ -1,4 +1,5 @@
 > {-# LANGUAGE DataKinds #-}
+> {-# LANGUAGE DerivingVia #-}
 > {-# LANGUAGE TemplateHaskell #-}
 > {-# LANGUAGE TypeFamilies #-}
 > {-# LANGUAGE UndecidableInstances #-}
@@ -13,6 +14,7 @@
 >
 > import "crem" Crem.BaseMachine
 > import "crem" Crem.Render.Render
+> import "crem" Crem.Render.RenderableVertices (AllVertices(..), RenderableVertices)
 > import "crem" Crem.Render.RenderFlow
 > import "crem" Crem.StateMachine
 > import "crem" Crem.Topology
@@ -47,6 +49,10 @@ Moreover, we want those switches to be usable only once, and therefore we want t
 >  )
 
 Notice that we need to wrap this in `singletons` because we will soon need to use this data type as a kind, to store information in the type of our state machines.
+
+We need also an instance of `RenderableVertices SwitchVertex` to decide which vertices to render for our machine. To obtain that, we use `deriving via` together with the `AllVertices` newtype.
+
+> deriving via AllVertices SwitchVertex instance RenderableVertices SwitchVertex
 
 Next we need to define which data every vertex of our topology should contain. To express that we use a generalized algebraid data type indexed with `SwitchVertex`
 
@@ -108,6 +114,8 @@ Again, we need to start thinking about the topology of our machine. Since we nee
 >         ]
 >     |]
 >  )
+>
+> deriving via AllVertices BothVertex instance RenderableVertices BothVertex
 
 The topology again constrains the machine with the invariant the we can only turn on switches.
 

--- a/examples/Crem/Example/Uno.hs
+++ b/examples/Crem/Example/Uno.hs
@@ -19,6 +19,7 @@ module Crem.Example.Uno where
 
 import Crem.BaseMachine (InitialState (..))
 import Crem.Decider (Decider (..), EvolutionResult (..))
+import Crem.Render.RenderableVertices (AllVertices (..), RenderableVertices)
 import Crem.Topology
 import "singletons-base" Data.Singletons.Base.TH
 import Prelude hiding (id, init, reverse)
@@ -177,6 +178,8 @@ $( singletons
       unoTopology = Topology [(Initial, [Started])]
       |]
  )
+
+deriving via AllVertices UnoVertex instance RenderableVertices UnoVertex
 
 -- * State
 

--- a/src/Crem/Render/RenderableVertices.hs
+++ b/src/Crem/Render/RenderableVertices.hs
@@ -1,27 +1,98 @@
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 -- | The `RenderableVertices` class describes which values of type @a@ should
 -- be rendered when drawing a graph (or a topology) with vertices of type @a@
 module Crem.Render.RenderableVertices where
 
+import "base" Data.Functor.Const (Const (..))
+import "base" Data.Functor.Identity (Identity (..))
+import "base" Data.Monoid (Dual (..), Product (..), Sum (..))
+import "base" Data.Ord (Down (..))
+import "base" Data.Proxy (Proxy (..))
+import "base" Data.Semigroup (All (..), Any (..), First (..), Last (..), Max (..), Min (..))
+import "base" Data.Void (Void)
+
 -- | The `RenderableVertices` class is implemented just as a list of elements
 -- of type @a@.
 class RenderableVertices a where
   vertices :: [a]
 
--- | If @a@ has `Enum` and `Bounded` instances, we have a way to enumerate all
--- the terms of type @a@.
---
--- Be careful to use this instance for types which are actually too big, like
--- `Int`. You probably don't want to print out every possible integer.
-instance {-# OVERLAPPABLE #-} (Enum a, Bounded a) => RenderableVertices a where
-  vertices :: [a]
-  vertices = [minBound .. maxBound]
+-- | This is a newtype to be used with `deriving via`. If `a` has instances for
+-- `Enum` and `Bounded`, then `AllVertices a` has an instance of
+-- `RenderableVertices` which lists all the terms of type `a`.
+newtype AllVertices a = AllVertices a
+
+instance (Enum a, Bounded a) => RenderableVertices (AllVertices a) where
+  vertices :: [AllVertices a]
+  vertices = AllVertices <$> [minBound .. maxBound]
+
+instance RenderableVertices Void where
+  vertices :: [Void]
+  vertices = []
+
+deriving via AllVertices () instance RenderableVertices ()
+
+deriving via AllVertices Bool instance RenderableVertices Bool
+
+instance RenderableVertices All where
+  vertices :: [All]
+  vertices = [All False, All True]
+
+instance RenderableVertices Any where
+  vertices :: [Any]
+  vertices = [Any False, Any True]
+
+deriving via AllVertices Ordering instance RenderableVertices Ordering
 
 instance RenderableVertices a => RenderableVertices (Maybe a) where
   vertices :: [Maybe a]
   vertices =
     Nothing : (Just <$> vertices)
+
+instance RenderableVertices a => RenderableVertices (Min a) where
+  vertices :: [Min a]
+  vertices = Min <$> vertices
+
+instance RenderableVertices a => RenderableVertices (Max a) where
+  vertices :: [Max a]
+  vertices = Max <$> vertices
+
+instance RenderableVertices a => RenderableVertices (First a) where
+  vertices :: [First a]
+  vertices = First <$> vertices
+
+instance RenderableVertices a => RenderableVertices (Last a) where
+  vertices :: [Last a]
+  vertices = Last <$> vertices
+
+instance RenderableVertices a => RenderableVertices (Identity a) where
+  vertices :: [Identity a]
+  vertices = Identity <$> vertices
+
+instance RenderableVertices a => RenderableVertices (Dual a) where
+  vertices :: [Dual a]
+  vertices = Dual <$> vertices
+
+instance RenderableVertices a => RenderableVertices (Sum a) where
+  vertices :: [Sum a]
+  vertices = Sum <$> vertices
+
+instance RenderableVertices a => RenderableVertices (Down a) where
+  vertices :: [Down a]
+  vertices = Down <$> vertices
+
+instance RenderableVertices a => RenderableVertices (Product a) where
+  vertices :: [Product a]
+  vertices = Product <$> vertices
+
+instance RenderableVertices (Proxy a) where
+  vertices :: [Proxy a]
+  vertices = [Proxy]
+
+instance RenderableVertices a => RenderableVertices (Const a b) where
+  vertices :: [Const a b]
+  vertices = Const <$> vertices
 
 instance (RenderableVertices a, RenderableVertices b) => RenderableVertices (Either a b) where
   vertices :: [Either a b]
@@ -32,3 +103,27 @@ instance (RenderableVertices a, RenderableVertices b) => RenderableVertices (Eit
 instance (RenderableVertices a, RenderableVertices b) => RenderableVertices (a, b) where
   vertices :: [(a, b)]
   vertices = [(a, b) | a <- vertices, b <- vertices]
+
+instance (RenderableVertices a, RenderableVertices b, RenderableVertices c) => RenderableVertices (a, b, c) where
+  vertices :: [(a, b, c)]
+  vertices = [(a, b, c) | a <- vertices, b <- vertices, c <- vertices]
+
+instance (RenderableVertices a, RenderableVertices b, RenderableVertices c, RenderableVertices d) => RenderableVertices (a, b, c, d) where
+  vertices :: [(a, b, c, d)]
+  vertices = [(a, b, c, d) | a <- vertices, b <- vertices, c <- vertices, d <- vertices]
+
+instance (RenderableVertices a, RenderableVertices b, RenderableVertices c, RenderableVertices d, RenderableVertices e) => RenderableVertices (a, b, c, d, e) where
+  vertices :: [(a, b, c, d, e)]
+  vertices = [(a, b, c, d, e) | a <- vertices, b <- vertices, c <- vertices, d <- vertices, e <- vertices]
+
+instance (RenderableVertices a, RenderableVertices b, RenderableVertices c, RenderableVertices d, RenderableVertices e, RenderableVertices f) => RenderableVertices (a, b, c, d, e, f) where
+  vertices :: [(a, b, c, d, e, f)]
+  vertices = [(a, b, c, d, e, f) | a <- vertices, b <- vertices, c <- vertices, d <- vertices, e <- vertices, f <- vertices]
+
+instance (RenderableVertices a, RenderableVertices b, RenderableVertices c, RenderableVertices d, RenderableVertices e, RenderableVertices f, RenderableVertices g) => RenderableVertices (a, b, c, d, e, f, g) where
+  vertices :: [(a, b, c, d, e, f, g)]
+  vertices = [(a, b, c, d, e, f, g) | a <- vertices, b <- vertices, c <- vertices, d <- vertices, e <- vertices, f <- vertices, g <- vertices]
+
+instance (RenderableVertices a, RenderableVertices b, RenderableVertices c, RenderableVertices d, RenderableVertices e, RenderableVertices f, RenderableVertices g, RenderableVertices h) => RenderableVertices (a, b, c, d, e, f, g, h) where
+  vertices :: [(a, b, c, d, e, f, g, h)]
+  vertices = [(a, b, c, d, e, f, g, h) | a <- vertices, b <- vertices, c <- vertices, d <- vertices, e <- vertices, f <- vertices, g <- vertices, h <- vertices]

--- a/src/Crem/Render/RenderableVertices.hs
+++ b/src/Crem/Render/RenderableVertices.hs
@@ -35,13 +35,9 @@ deriving via AllVertices () instance RenderableVertices ()
 
 deriving via AllVertices Bool instance RenderableVertices Bool
 
-instance RenderableVertices All where
-  vertices :: [All]
-  vertices = [All False, All True]
+deriving newtype instance RenderableVertices All
 
-instance RenderableVertices Any where
-  vertices :: [Any]
-  vertices = [Any False, Any True]
+deriving newtype instance RenderableVertices Any
 
 deriving via AllVertices Ordering instance RenderableVertices Ordering
 
@@ -50,49 +46,29 @@ instance RenderableVertices a => RenderableVertices (Maybe a) where
   vertices =
     Nothing : (Just <$> vertices)
 
-instance RenderableVertices a => RenderableVertices (Min a) where
-  vertices :: [Min a]
-  vertices = Min <$> vertices
+deriving newtype instance RenderableVertices a => RenderableVertices (Min a)
 
-instance RenderableVertices a => RenderableVertices (Max a) where
-  vertices :: [Max a]
-  vertices = Max <$> vertices
+deriving newtype instance RenderableVertices a => RenderableVertices (Max a)
 
-instance RenderableVertices a => RenderableVertices (First a) where
-  vertices :: [First a]
-  vertices = First <$> vertices
+deriving newtype instance RenderableVertices a => RenderableVertices (First a)
 
-instance RenderableVertices a => RenderableVertices (Last a) where
-  vertices :: [Last a]
-  vertices = Last <$> vertices
+deriving newtype instance RenderableVertices a => RenderableVertices (Last a)
 
-instance RenderableVertices a => RenderableVertices (Identity a) where
-  vertices :: [Identity a]
-  vertices = Identity <$> vertices
+deriving newtype instance RenderableVertices a => RenderableVertices (Identity a)
 
-instance RenderableVertices a => RenderableVertices (Dual a) where
-  vertices :: [Dual a]
-  vertices = Dual <$> vertices
+deriving newtype instance RenderableVertices a => RenderableVertices (Dual a)
 
-instance RenderableVertices a => RenderableVertices (Sum a) where
-  vertices :: [Sum a]
-  vertices = Sum <$> vertices
+deriving newtype instance RenderableVertices a => RenderableVertices (Sum a)
 
-instance RenderableVertices a => RenderableVertices (Down a) where
-  vertices :: [Down a]
-  vertices = Down <$> vertices
+deriving newtype instance RenderableVertices a => RenderableVertices (Down a)
 
-instance RenderableVertices a => RenderableVertices (Product a) where
-  vertices :: [Product a]
-  vertices = Product <$> vertices
+deriving newtype instance RenderableVertices a => RenderableVertices (Product a)
 
 instance RenderableVertices (Proxy a) where
   vertices :: [Proxy a]
   vertices = [Proxy]
 
-instance RenderableVertices a => RenderableVertices (Const a b) where
-  vertices :: [Const a b]
-  vertices = Const <$> vertices
+deriving newtype instance RenderableVertices a => RenderableVertices (Const a b)
 
 instance (RenderableVertices a, RenderableVertices b) => RenderableVertices (Either a b) where
   vertices :: [Either a b]


### PR DESCRIPTION
instead of providing a default `RenderableVertices` instance for every type with `Enum` and `Bounded` instances, we provide a newtype wrapper to be used with `DerivingVia`

closes #75 